### PR TITLE
Extracted interface for SurveyMonkeyApi

### DIFF
--- a/SurveyMonkey/ISurveyMonkeyApi.cs
+++ b/SurveyMonkey/ISurveyMonkeyApi.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+
+namespace SurveyMonkey
+{
+    public interface ISurveyMonkeyApi
+    {
+        int RequestsMade { get; }
+        int QuotaAllotted { get; }
+        int QuotaUsed { get; }
+
+        List<Survey> GetSurveyList();
+        List<Survey> GetSurveyList(GetSurveyListSettings settings);
+
+        ///No limit on page size
+        List<Survey> GetSurveyList(int page, GetSurveyListSettings settings);
+
+        List<Survey> GetSurveyList(int page);
+        List<Survey> GetSurveyList(int page, int pageSize, GetSurveyListSettings settings);
+        List<Survey> GetSurveyList(int page, int pageSize);
+
+        Survey GetSurveyDetails(long surveyId);
+
+        List<Collector> GetCollectorList(long surveyId);
+        List<Collector> GetCollectorList(long surveyId, GetCollectorListSettings settings);
+
+        ///No limit on page size
+        List<Collector> GetCollectorList(long surveyId, int page, GetCollectorListSettings settings);
+
+        List<Collector> GetCollectorList(long surveyId, int page);
+        List<Collector> GetCollectorList(long surveyId, int page, int pageSize);
+        List<Collector> GetCollectorList(long surveyId, int page, int pageSize, GetCollectorListSettings settings);
+
+        List<Respondent> GetRespondentList(long surveyId);
+        List<Respondent> GetRespondentList(long surveyId, GetRespondentListSettings settings);
+
+        ///No limit on page size
+        List<Respondent> GetRespondentList(long surveyId, int page, GetRespondentListSettings settings);
+
+        List<Respondent> GetRespondentList(long surveyId, int page);
+        List<Respondent> GetRespondentList(long surveyId, int page, int pageSize, GetRespondentListSettings settings);
+        List<Respondent> GetRespondentList(long surveyId, int page, int pageSize);
+        List<Response> GetResponses(long surveyId, List<long> respondents);
+        
+        Collector GetResponseCounts(long collectorId);
+        
+        UserDetails GetUserDetails();
+        
+        void FillMissingSurveyInformation(List<Survey> surveys);
+        void FillMissingSurveyInformation(Survey survey);
+    }
+}

--- a/SurveyMonkey/SurveyMonkey.csproj
+++ b/SurveyMonkey/SurveyMonkey.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Enums.cs" />
+    <Compile Include="ISurveyMonkeyApi.cs" />
     <Compile Include="Json.cs" />
     <Compile Include="Responses.cs" />
     <Compile Include="SurveyMonkeyApi.Endpoints.cs">

--- a/SurveyMonkey/SurveyMonkeyApi.Endpoints.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.Endpoints.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace SurveyMonkey
 {
-    public partial class SurveyMonkeyApi
+    public partial class SurveyMonkeyApi : ISurveyMonkeyApi
     {
         #region GetSurveyList endpoint
 

--- a/SurveyMonkey/SurveyMonkeyApi.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json.Linq;
 
 namespace SurveyMonkey
 {
-    public partial class SurveyMonkeyApi
+    public partial class SurveyMonkeyApi 
     {
         #region Members
 


### PR DESCRIPTION
I took a dive into the code base. It didn't make much sense to extract any other interfaces IMO. Everything else was more or less just a container with no real logic inside. This should be enough to make sure tests don't have to hit the actual web service. Closes #3.
