### PR TITLE
Store EmailIds when creating new email collectors

### DIFF
--- a/SurveyMonkey/Containers.cs
+++ b/SurveyMonkey/Containers.cs
@@ -231,6 +231,7 @@ namespace SurveyMonkey
         public Survey Survey { get; set; }
         public Collector Collector { get; set; }
         public RecipientsReport RecipientsReport { get; set; }
+        public EmailMessage EmailMessage { get; set; }
     }
 
     [JsonConverter(typeof(LaxPropertyNameJsonConverter))]
@@ -239,6 +240,13 @@ namespace SurveyMonkey
         public Survey Survey { get; set; }
         public Collector Collector { get; set; }
         public RecipientsReport RecipientsReport { get; set; }
+        public EmailMessage EmailMessage { get; set; }
+    }
+
+    [JsonConverter(typeof (LaxPropertyNameJsonConverter))]
+    public class EmailMessage
+    {
+        public long EmailMessageId { get; set; }
     }
 
     [JsonConverter(typeof(LaxPropertyNameJsonConverter))]

--- a/SurveyMonkey/SurveyMonkeyApi.Endpoints.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.Endpoints.cs
@@ -518,6 +518,7 @@ namespace SurveyMonkey
                 response.Survey = rawSurvey.ToSurvey();
                 response.Collector = o["collector"].ToObject<Collector>();
                 response.RecipientsReport = o["recipients_report"].ToObject<RecipientsReport>();
+                response.EmailMessage = o["email_message"].ToObject<EmailMessage>();
                 return response;
             }
             catch (Exception e)
@@ -543,6 +544,7 @@ namespace SurveyMonkey
                 response.Survey = rawSurvey.ToSurvey();
                 response.Collector = o["collector"].ToObject<Collector>();
                 response.RecipientsReport = o["recipients_report"].ToObject<RecipientsReport>();
+                response.EmailMessage = o["email_message"].ToObject<EmailMessage>();
                 return response;
             }
             catch (Exception e)


### PR DESCRIPTION
In SendFlow and CreateFlow. These are useful because they can later be used with CreateRecipients
